### PR TITLE
Link updates

### DIFF
--- a/embed.html
+++ b/embed.html
@@ -209,7 +209,7 @@
 We do not accept the orthodoxy that the debate over gun control is simply too difficult. Our new series, <a href='https://www.
 theguardian.com/us-news/series/break-the-cycle' target='_parent'>Break the Cycle</a>, will drive a conversation about solutions beyond Washington and hold politicians to account for ignoring reforms that could save lives.</div>
 
-            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com">Contribute now</a>
+            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com?INTCMP=us_gun_campaign_2017">Contribute now</a>
         </div>
     </div>
 

--- a/embed.html
+++ b/embed.html
@@ -12,7 +12,7 @@
         iframeMessenger.enableAutoResize();
 
         iframeMessenger.enrichAcquisitionLinks({
-            componentType: 'ACQUISITIONS_EMBED',
+            componentType: 'ACQUISITIONS_OTHER',
             componentId: 'gdnwb_embed_us_gun_campaign_2017',
             source: 'GUARDIAN_WEB',
             campaignCode: 'us_gun_campaign_2017'
@@ -209,7 +209,7 @@
 We do not accept the orthodoxy that the debate over gun control is simply too difficult. Our new series, <a href='https://www.
 theguardian.com/us-news/series/break-the-cycle' target='_parent'>Break the Cycle</a>, will drive a conversation about solutions beyond Washington and hold politicians to account for ignoring reforms that could save lives.</div>
 
-            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com/us?INTCMP=us_gun_campaign_2017">Contribute now</a>
+            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com">Contribute now</a>
         </div>
     </div>
 

--- a/epic.html
+++ b/epic.html
@@ -211,7 +211,7 @@ theguardian.com/us-news/series/break-the-cycle' target='_parent'>Break the Cycle
 Politicians often insist after mass shootings that “now is not the time” to discuss reform. We believe now is the time. By keeping the issue of gun violence in the public eye outside of major tragedies, we can drive a conversation and create meaningful change.
             </div>
 
-            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com">Contribute now</a>
+            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com?INTCMP=us_gun_campaign_2017">Contribute now</a>
         </div>
     </div>
 

--- a/epic.html
+++ b/epic.html
@@ -211,7 +211,7 @@ theguardian.com/us-news/series/break-the-cycle' target='_parent'>Break the Cycle
 Politicians often insist after mass shootings that “now is not the time” to discuss reform. We believe now is the time. By keeping the issue of gun violence in the public eye outside of major tragedies, we can drive a conversation and create meaningful change.
             </div>
 
-            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com/us?INTCMP=us_gun_campaign_2017">Contribute now</a>
+            <a target="_parent" class="button js-acquisition-link" href="https://contribute.theguardian.com">Contribute now</a>
         </div>
     </div>
 


### PR DESCRIPTION
This pull request:

- removes path `/us` (user location inferred by contributions)
- uses `ACQUISITIONS_OTHER` for the component type of an embed

Even though the `INTCMP` query parameter _should_ be redundant (as the acquisition links are getting enriched), keep it in, just in case the link enrichment logic fails.